### PR TITLE
Exception codes changed in Test Methods

### DIFF
--- a/CareerCloud.UnitTests.Assignment3/Assignment3Marking.cs
+++ b/CareerCloud.UnitTests.Assignment3/Assignment3Marking.cs
@@ -960,7 +960,7 @@ namespace CareerCloud.UnitTests.Assignment3
             catch (AggregateException e )
             {
                 IEnumerable<ValidationException> exceptions = e.InnerExceptions.Cast<ValidationException>();
-                Assert.IsTrue(exceptions.Any(ex => ex.Code == 601));
+                Assert.IsTrue(exceptions.Any(ex => ex.Code == 600));
             }
         }
 
@@ -977,7 +977,7 @@ namespace CareerCloud.UnitTests.Assignment3
             catch (AggregateException e)
             {
                 IEnumerable<ValidationException> exceptions = e.InnerExceptions.Cast<ValidationException>();
-                Assert.IsTrue(exceptions.Any(ex => ex.Code == 601));
+                Assert.IsTrue(exceptions.Any(ex => ex.Code == 600));
             }
         }
 

--- a/CareerCloud.UnitTests.Assignment3/Assignment3Marking.cs
+++ b/CareerCloud.UnitTests.Assignment3/Assignment3Marking.cs
@@ -873,7 +873,7 @@ namespace CareerCloud.UnitTests.Assignment3
             catch (AggregateException e)
             {
                 IEnumerable<ValidationException> exceptions = e.InnerExceptions.Cast<ValidationException>();
-                Assert.IsTrue(exceptions.Any(ex => ex.Code == 501));
+                Assert.IsTrue(exceptions.Any(ex => ex.Code == 502));
             }
         }
 

--- a/CareerCloud.UnitTests.Assignment3/CareerCloud.UnitTests.Assignment3.csproj
+++ b/CareerCloud.UnitTests.Assignment3/CareerCloud.UnitTests.Assignment3.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -42,10 +42,10 @@
       <HintPath>..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.7.63.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.7.63\lib\net45\Moq.dll</HintPath>
@@ -61,14 +61,32 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CareerCloud.ADODataAccessLayer\CareerCloud.ADODataAccessLayer.csproj">
+      <Project>{284facfa-966e-4016-8a39-a92c0637b3d2}</Project>
+      <Name>CareerCloud.ADODataAccessLayer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\CareerCloud.BusinessLogicLayer\CareerCloud.BusinessLogicLayer.csproj">
+      <Project>{bc1c7fb2-6676-4fd4-b281-fa3f0acbb7ec}</Project>
+      <Name>CareerCloud.BusinessLogicLayer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\CareerCloud.DataAccessLayer\CareerCloud.DataAccessLayer.csproj">
+      <Project>{95844af3-bc02-4e5f-860e-96b18e541c21}</Project>
+      <Name>CareerCloud.DataAccessLayer</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\CareerCloud.Pocos\CareerCloud.Pocos.csproj">
+      <Project>{facb9a11-546f-4a1e-b20b-df66a299f246}</Project>
+      <Name>CareerCloud.Pocos</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/CareerCloud.UnitTests.Assignment3/packages.config
+++ b/CareerCloud.UnitTests.Assignment3/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Castle.Core" version="4.1.1" targetFramework="net452" />
   <package id="Moq" version="4.7.63" targetFramework="net452" />
-  <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net452" />
-  <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net452" />
+  <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Hi John,

I changed the exception codes in the following test methods to match exception codes in the rules table:

CompanyProfile_WebSite_Sufix_Add_Test()          : to check for exception code 600 instead of 601
CompanyProfile_WebSite_Sufix_Update_Test()     :  to check for exception code 600 instead of 601
CompanyLocation_Street_CannotBeEmpty_Update_Test() : to check for exception code 502 instead of 501

Thanks,

Hassan